### PR TITLE
fix: engines config is far too strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "phenix-web-observable": "^2020.0.1"
   },
   "engines": {
-    "node": "12.18.2"
+    "node": ">= 12.18.2"
   },
   "devDependencies": {
     "bluebird": "3.7.2",


### PR DESCRIPTION
Fixes https://github.com/PhenixRTS/RTC/issues/4

The engines config is much too strict. Is there a valid reason why we want to lock to a specific version of Node?

It seems like this has been around since the very origin of this repo https://github.com/PhenixRTS/RTC/commit/02d3c72289197810b68c84cafd06ed3986329a36#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R23

I definitely understand why some people want their dev environment to use a specific version of node, such as how [Volta](https://github.com/volta-cli/volta) works, but this effectively prevents anyone from enabling the `engine-strict` npm option.

https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines

The npm docs say that the engines config is to "specify the version of node that your stuff works on" which is definitely more than one specific version of node.

Can we please relax this config?

-----

Alternatively, I'd suggest we can use

```
  "engines": {
    "node": "^12.18.2 || ^14 || ^16"
  },
```

if you want to be more specific